### PR TITLE
Vote Schema Definition

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Description
+-- Insert description here--
+
+## How to Test
+-- Define how to test here--

--- a/src/modules/vote/__tests__/vote.schema.ts
+++ b/src/modules/vote/__tests__/vote.schema.ts
@@ -1,0 +1,17 @@
+
+import { voteResolvers } from '../vote.schema'
+
+describe('vote resolvers', () => {
+  describe('Query', () => {
+    describe('votes', () => {
+      it('should return votes', () => {
+        const sessionId = '12354'
+
+        voteResolvers.Query.votes.resolve({}, { sessionId })
+          .then(result => {
+            expect(result).toEqual([ { content: '1' }, { content: '3' } ])
+          })
+      })
+    })
+  })
+})

--- a/src/modules/vote/vote.schema.ts
+++ b/src/modules/vote/vote.schema.ts
@@ -1,0 +1,31 @@
+import { IResolvers } from 'apollo-server'
+import gql from '../../helpers/noopTag'
+import { Context } from '../../context'
+
+import { Vote } from './vote.types'
+
+export const typeDefs = gql`
+  extend type Query {
+    votes (sessionId: String): [Vote!]!
+  }
+
+  type Vote implements Document {
+    _id: ID!
+    content: String!
+  }
+`
+
+export const voteResolvers = {
+  Query: {
+    votes: {
+      description: 'Used to retrieve all votes.',
+      async resolve (_source: any, { sessionId }: { sessionId: String }): Promise<Vote[]> {
+        return [ { content: '1' }, { content: '3' } ]
+      },
+    },
+  },
+  Subscription: {
+  },
+}
+
+export const resolvers: IResolvers<Vote, Context> = voteResolvers

--- a/src/modules/vote/vote.types.d.ts
+++ b/src/modules/vote/vote.types.d.ts
@@ -1,0 +1,3 @@
+export interface Vote  {
+  content: string
+}


### PR DESCRIPTION
## Description
Added foundation for defining the new Vote type; added resolver to query hardcoded list of votes

## How to Test
run `npm test` in the server repo.
Navigtate to `http://localhost:3001` and attempt to query:
```graphql
{
  votes(sessionId: "123") {
    content
  }
}
```